### PR TITLE
Use fs-cp instead of save-to to make this pkg work cross device

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   },
   "homepage": "https://github.com/QubitProducts/s3-cnpm",
   "dependencies": {
+    "cp": "^0.2.0",
+    "fs-cp": "^1.3.0",
     "knox": "^0.9.1",
-    "save-to": "^1.0.3",
     "thunkify": "^2.1.2",
     "when": "^3.5.0"
   },

--- a/s3-cnpm.js
+++ b/s3-cnpm.js
@@ -5,7 +5,7 @@ var path = require('path');
 var knox = require('knox');
 var when = require('when');
 var thunkify = require('thunkify');
-var saveTo = thunkify(require('save-to'));
+var cp = require('fs-cp');
 
 module.exports = function (config) {
   return new S3(config);
@@ -100,7 +100,7 @@ S3.prototype.download = function* (key, savePath) {
   var client = this.client;
   var filepath = this.getPath(key);
   var res = yield client.getFile(filepath);
-  yield saveTo(res, savePath);
+  yield cp(res, savePath);
 };
 
 /**


### PR DESCRIPTION
nodejs.EXDEVErrorException: Error: EXDEV, rename '/tmp/s7pj58b55nze61or'

`save-to` was creating a temporary directory at os.tmp() (/tmp) which would break if that's on a different disk than the target path you're downloading the package to.

`fs-cp` works better all around
